### PR TITLE
feat: Sign Up Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The name **Bucin** comes from the Indonesian phrase "Budak Cinta" (meaning "Love
 This project is currently under development. Here are the planned stages:
 
 - [x] Project initialization
-- [ ] Authentication (Login & Sign Up pages) (**current stage**)
-- [ ] Love letter sending & receiving
+- [x] Authentication (Login & Sign Up pages)
+- [ ] Love letter sending & receiving (**current stage**)
 - [ ] Couple dashboard
 - [ ] Notification system
 - [ ] Responsive & modern UI
@@ -61,7 +61,7 @@ Follow these steps to set up and run the project locally:
 
 ## 📋 Planned Features
 
-- [ ] Modern login & sign up pages
+- [x] Modern login & sign up pages
 - [ ] Send and receive love letters
 - [ ] Couple dashboard
 - [ ] Push notifications

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,7 @@
-import './App.css';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { LandingPage } from './pages/LandingPage';
 import { LoginPage } from './pages/LoginPage';
 import { SignUpPage } from './pages/SignUpPage';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
 function App() {
   return (

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,4 +1,12 @@
-import { Box, Button, Typography, FormControl, InputLabel, OutlinedInput } from '@mui/material';
+import {
+  Box,
+  Button,
+  Typography,
+  FormControl,
+  InputLabel,
+  OutlinedInput,
+  Grid,
+} from '@mui/material';
 import { BlinkParticlesComponent } from '../components/BlinkParticlesComponent';
 import { useTheme, alpha } from '@mui/material/styles';
 import { NavbarComponent } from '../components/NavbarComponent';
@@ -18,18 +26,8 @@ export const LoginPage = () => {
   const isSuccess = status.user.login === 'SUCCESS';
 
   const handleLogin = (values, { setSubmitting }) => {
-    dispatch(authAsyncAction(values)).finally(() => setSubmitting(false));
+    dispatch(authAsyncAction.login(values)).finally(() => setSubmitting(false));
   };
-
-  useEffect(() => {
-    if (isSuccess) {
-      setTimeout(() => {
-        nav('../dashboard');
-        dispatch(setStatus({ type: 'user', status: 'IDLE' }));
-        Formik.resetForm();
-      }, 1000);
-    }
-  }, [isSuccess]);
 
   return (
     <Box
@@ -61,113 +59,132 @@ export const LoginPage = () => {
             Login
           </Typography>
           <Formik initialValues={{ email: '', password: '' }} onSubmit={handleLogin}>
-            {({ values, handleChange, handleBlur, handleSubmit, isSubmitting }) => (
-              <Box component="form" sx={{ width: '100%' }} onSubmit={handleSubmit}>
-                <Box mb={2}>
-                  <FormControl
-                    fullWidth
-                    variant="outlined"
-                    sx={{
-                      mb: 1,
-                      borderRadius: 2,
-                      background: alpha(theme.palette.background.paper, 0.35),
-                    }}
-                  >
-                    <InputLabel htmlFor="login-email" sx={{ color: theme.palette.text.secondary }}>
-                      Email
-                    </InputLabel>
-                    <OutlinedInput
-                      id="login-email"
-                      name="email"
-                      type="email"
-                      label="Email"
-                      value={values.email}
-                      onChange={handleChange}
-                      onBlur={handleBlur}
+            {({ values, handleChange, handleBlur, handleSubmit, isSubmitting, resetForm }) => {
+              useEffect(() => {
+                if (isSuccess) {
+                  setTimeout(() => {
+                    nav('../dashboard');
+                    dispatch(
+                      setStatus({ type: 'user', status: { ...status.user, login: 'IDLE' } })
+                    );
+                    resetForm();
+                  }, 1000);
+                }
+              }, [isSuccess, nav, dispatch, resetForm, status.user]);
+              return (
+                <Box component="form" sx={{ width: '100%' }} onSubmit={handleSubmit}>
+                  <Box mb={2}>
+                    <FormControl
+                      fullWidth
+                      variant="outlined"
                       sx={{
-                        color: theme.palette.text.primary,
+                        mb: 1,
                         borderRadius: 2,
-                        '& .MuiOutlinedInput-notchedOutline': {
-                          borderColor: theme.palette.divider,
-                        },
-                        '&:hover .MuiOutlinedInput-notchedOutline': {
-                          borderColor: theme.palette.primary.main,
-                        },
-                        background: 'transparent',
+                        background: alpha(theme.palette.background.paper, 0.35),
                       }}
-                    />
-                  </FormControl>
-                </Box>
-                <Box mb={3}>
-                  <FormControl
-                    fullWidth
-                    variant="outlined"
-                    sx={{
-                      mb: 1,
-                      borderRadius: 2,
-                      background: alpha(theme.palette.background.paper, 0.35),
-                    }}
-                  >
-                    <InputLabel
-                      htmlFor="login-password"
-                      sx={{ color: theme.palette.text.secondary }}
                     >
-                      Password
-                    </InputLabel>
-                    <OutlinedInput
-                      id="login-password"
-                      name="password"
-                      type="password"
-                      label="Password"
-                      value={values.password}
-                      onChange={handleChange}
-                      onBlur={handleBlur}
+                      <InputLabel
+                        htmlFor="login-email"
+                        sx={{ color: theme.palette.text.secondary }}
+                      >
+                        Email
+                      </InputLabel>
+                      <OutlinedInput
+                        id="login-email"
+                        name="email"
+                        type="email"
+                        label="Email"
+                        value={values.email}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        sx={{
+                          color: theme.palette.text.primary,
+                          borderRadius: 2,
+                          '& .MuiOutlinedInput-notchedOutline': {
+                            borderColor: theme.palette.divider,
+                          },
+                          '&:hover .MuiOutlinedInput-notchedOutline': {
+                            borderColor: theme.palette.primary.main,
+                          },
+                          background: 'transparent',
+                        }}
+                      />
+                    </FormControl>
+                  </Box>
+                  <Box mb={3}>
+                    <FormControl
+                      fullWidth
+                      variant="outlined"
                       sx={{
-                        color: theme.palette.text.primary,
+                        mb: 1,
                         borderRadius: 2,
-                        '& .MuiOutlinedInput-notchedOutline': {
-                          borderColor: theme.palette.divider,
-                        },
-                        '&:hover .MuiOutlinedInput-notchedOutline': {
-                          borderColor: theme.palette.primary.main,
-                        },
-                        background: 'transparent',
+                        background: alpha(theme.palette.background.paper, 0.35),
                       }}
-                    />
-                  </FormControl>
+                    >
+                      <InputLabel
+                        htmlFor="login-password"
+                        sx={{ color: theme.palette.text.secondary }}
+                      >
+                        Password
+                      </InputLabel>
+                      <OutlinedInput
+                        id="login-password"
+                        name="password"
+                        type="password"
+                        label="Password"
+                        value={values.password}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        sx={{
+                          color: theme.palette.text.primary,
+                          borderRadius: 2,
+                          '& .MuiOutlinedInput-notchedOutline': {
+                            borderColor: theme.palette.divider,
+                          },
+                          '&:hover .MuiOutlinedInput-notchedOutline': {
+                            borderColor: theme.palette.primary.main,
+                          },
+                          background: 'transparent',
+                        }}
+                      />
+                    </FormControl>
+                  </Box>
+                  <Box textAlign="center">
+                    <Button
+                      type="submit"
+                      variant="contained"
+                      color="primary"
+                      fullWidth
+                      disabled={isSubmitting}
+                      sx={{
+                        borderRadius: 2,
+                        fontWeight: 700,
+                        fontSize: 16,
+                        py: 1.5,
+                        boxShadow: theme.shadows[2],
+                        textTransform: 'none',
+                      }}
+                    >
+                      {isSubmitting ? 'Loading...' : 'Log In'}
+                    </Button>
+                    {error && (
+                      <Typography color="error" mt={2}>
+                        {error}
+                      </Typography>
+                    )}
+                    {user && (
+                      <Typography color="success.main" mt={2}>
+                        Login succeed!
+                      </Typography>
+                    )}
+                  </Box>
                 </Box>
-                <Box textAlign="center">
-                  <Button
-                    type="submit"
-                    variant="contained"
-                    color="primary"
-                    fullWidth
-                    disabled={isSubmitting}
-                    sx={{
-                      borderRadius: 2,
-                      fontWeight: 700,
-                      fontSize: 16,
-                      py: 1.5,
-                      boxShadow: theme.shadows[2],
-                      textTransform: 'none',
-                    }}
-                  >
-                    {isSubmitting ? 'Loading...' : 'Log In'}
-                  </Button>
-                  {error && (
-                    <Typography color="error" mt={2}>
-                      {error}
-                    </Typography>
-                  )}
-                  {user && (
-                    <Typography color="success.main" mt={2}>
-                      Login succeed!
-                    </Typography>
-                  )}
-                </Box>
-              </Box>
-            )}
+              );
+            }}
           </Formik>
+          <Grid mt={2}>
+            Didn't have an account? <Button onClick={() => nav('../signup')}>Sign Up</Button>
+          </Grid>
         </GlassBoxComponent>
       </Box>
     </Box>

--- a/src/pages/SignUpPage.jsx
+++ b/src/pages/SignUpPage.jsx
@@ -1,0 +1,260 @@
+import { Box, FormControl, Typography, InputLabel, OutlinedInput, Button } from '@mui/material';
+import { BlinkParticlesComponent } from '../components/BlinkParticlesComponent';
+import { NavbarComponent } from '../components/NavbarComponent';
+import { useTheme, alpha } from '@mui/material/styles';
+import { GlassBoxComponent } from '../components/GlassBoxComponent';
+import { Formik } from 'formik';
+import { useDispatch, useSelector } from 'react-redux';
+import { authAsyncAction } from '../store/authAsyncAction';
+import { useEffect } from 'react';
+import { setStatus } from '../store/authSlice';
+import { useNavigate } from 'react-router-dom';
+
+export const SignUpPage = () => {
+  const theme = useTheme();
+  const dispatch = useDispatch();
+  const { status, error } = useSelector((state) => state.auth);
+  const isSuccess = status.user.signup === 'SUCCESS';
+  const nav = useNavigate();
+
+  const handleSignUp = (values, { setSubmitting }) => {
+    dispatch(authAsyncAction.signup(values)).finally(() => setSubmitting(false));
+  };
+
+  return (
+    <Box
+      minHeight="100vh"
+      width="100%"
+      sx={{
+        position: 'relative',
+        overflow: 'hidden',
+        background: `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${theme.palette.pink.main} 100%)`,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <BlinkParticlesComponent />
+      <Box sx={{ pt: 2, boxShadow: 5, position: 'relative', zIndex: 1 }}>
+        <NavbarComponent />
+      </Box>
+      <Box
+        sx={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: 0,
+        }}
+      >
+        <GlassBoxComponent>
+          <Typography variant="h5" fontWeight={700} color={theme.palette.text.primary} mb={2}>
+            Create an Account
+          </Typography>
+          <Formik
+            onSubmit={handleSignUp}
+            initialValues={{ name: '', email: '', password: '', username: '' }}
+          >
+            {({ values, handleChange, handleBlur, handleSubmit, isSubmitting, resetForm }) => {
+              useEffect(() => {
+                if (isSuccess) {
+                  setTimeout(() => {
+                    nav('../login');
+                    dispatch(
+                      setStatus({ type: 'user', status: { ...status.user, signup: 'IDLE' } })
+                    );
+                    resetForm();
+                  }, 1000);
+                }
+              }, [isSuccess, nav, dispatch, resetForm, status.user]);
+              return (
+                <Box component="form" sx={{ width: '100%' }} onSubmit={handleSubmit}>
+                  <Box mb={2}>
+                    <FormControl
+                      fullWidth
+                      variant="outlined"
+                      sx={{
+                        mb: 1,
+                        borderRadius: 2,
+                        background: alpha(theme.palette.background.paper, 0.35),
+                      }}
+                    >
+                      <InputLabel
+                        htmlFor="signup-name"
+                        sx={{ color: theme.palette.text.secondary }}
+                      >
+                        Name
+                      </InputLabel>
+                      <OutlinedInput
+                        id="signup-name"
+                        name="name"
+                        type="text"
+                        label="Name"
+                        value={values.name}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        sx={{
+                          color: theme.palette.text.primary,
+                          borderRadius: 2,
+                          '& .MuiOutlinedInput-notchedOutline': {
+                            borderColor: theme.palette.divider,
+                          },
+                          '&:hover .MuiOutlinedInput-notchedOutline': {
+                            borderColor: theme.palette.primary.main,
+                          },
+                          background: 'transparent',
+                        }}
+                      />
+                    </FormControl>
+                  </Box>
+                  <Box mb={2}>
+                    <FormControl
+                      fullWidth
+                      variant="outlined"
+                      sx={{
+                        mb: 1,
+                        borderRadius: 2,
+                        background: alpha(theme.palette.background.paper, 0.35),
+                      }}
+                    >
+                      <InputLabel htmlFor="username" sx={{ color: theme.palette.text.secondary }}>
+                        Username
+                      </InputLabel>
+                      <OutlinedInput
+                        id="username"
+                        name="username"
+                        type="text"
+                        label="username"
+                        autoComplete="username"
+                        value={values.username}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        sx={{
+                          color: theme.palette.text.primary,
+                          borderRadius: 2,
+                          '& .MuiOutlinedInput-notchedOutline': {
+                            borderColor: theme.palette.divider,
+                          },
+                          '&:hover .MuiOutlinedInput-notchedOutline': {
+                            borderColor: theme.palette.primary.main,
+                          },
+                          background: 'transparent',
+                        }}
+                      />
+                    </FormControl>
+                  </Box>
+                  <Box mb={2}>
+                    <FormControl
+                      fullWidth
+                      variant="outlined"
+                      sx={{
+                        mb: 1,
+                        borderRadius: 2,
+                        background: alpha(theme.palette.background.paper, 0.35),
+                      }}
+                    >
+                      <InputLabel
+                        htmlFor="login-email"
+                        sx={{ color: theme.palette.text.secondary }}
+                      >
+                        Email
+                      </InputLabel>
+                      <OutlinedInput
+                        autoComplete="email"
+                        id="login-email"
+                        name="email"
+                        type="email"
+                        label="Email"
+                        value={values.email}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        sx={{
+                          color: theme.palette.text.primary,
+                          borderRadius: 2,
+                          '& .MuiOutlinedInput-notchedOutline': {
+                            borderColor: theme.palette.divider,
+                          },
+                          '&:hover .MuiOutlinedInput-notchedOutline': {
+                            borderColor: theme.palette.primary.main,
+                          },
+                          background: 'transparent',
+                        }}
+                      />
+                    </FormControl>
+                  </Box>
+                  <Box mb={3}>
+                    <FormControl
+                      fullWidth
+                      variant="outlined"
+                      sx={{
+                        mb: 1,
+                        borderRadius: 2,
+                        background: alpha(theme.palette.background.paper, 0.35),
+                      }}
+                    >
+                      <InputLabel
+                        htmlFor="login-password"
+                        sx={{ color: theme.palette.text.secondary }}
+                      >
+                        Password
+                      </InputLabel>
+                      <OutlinedInput
+                        autoComplete="new-password"
+                        id="login-password"
+                        name="password"
+                        type="password"
+                        label="Password"
+                        value={values.password}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        sx={{
+                          color: theme.palette.text.primary,
+                          borderRadius: 2,
+                          '& .MuiOutlinedInput-notchedOutline': {
+                            borderColor: theme.palette.divider,
+                          },
+                          '&:hover .MuiOutlinedInput-notchedOutline': {
+                            borderColor: theme.palette.primary.main,
+                          },
+                          background: 'transparent',
+                        }}
+                      />
+                    </FormControl>
+                  </Box>
+                  <Box textAlign="center">
+                    <Button
+                      type="submit"
+                      variant="contained"
+                      color="primary"
+                      fullWidth
+                      disabled={isSubmitting}
+                      sx={{
+                        borderRadius: 2,
+                        fontWeight: 700,
+                        fontSize: 16,
+                        py: 1.5,
+                        boxShadow: theme.shadows[2],
+                        textTransform: 'none',
+                      }}
+                    >
+                      {isSubmitting ? 'Loading...' : 'Sign Up'}
+                    </Button>
+                    {status.user.signup === 'REJECTED' && error && (
+                      <Typography color="error" mt={2}>
+                        {error}
+                      </Typography>
+                    )}
+                    {status.user.signup === 'SUCCESS' && (
+                      <Typography color="success.main" mt={2}>
+                        Signup succeed! Redirecting...
+                      </Typography>
+                    )}
+                  </Box>
+                </Box>
+              );
+            }}
+          </Formik>
+        </GlassBoxComponent>
+      </Box>
+    </Box>
+  );
+};

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -7,9 +7,15 @@ const api = axios.create({
   },
 });
 
-export const authService = async (email, password) => {
-  const response = await api.get(`/user?email=${email}&password=${password}`, { email, password });
-  return response.data;
+export const authService = {
+  login: async (email, password) => {
+    const response = await api.get(`/user?email=${email}&password=${password}`);
+    return response.data;
+  },
+  signup: async (userData) => {
+    const response = await api.post('/user', userData);
+    return response.data;
+  },
 };
 
 export default api;

--- a/src/store/authAsyncAction.js
+++ b/src/store/authAsyncAction.js
@@ -1,17 +1,20 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { authService as AuthSvc } from '../services/authService';
+import { authService } from '../services/authService';
 
-export const authAsyncAction = createAsyncThunk(
-  'auth/login',
-  async ({ email, password }, { rejectWithValue }) => {
-    try {
-      const data = await AuthSvc(email, password);
-      if (!data || !Array.isArray(data) || data.length === 0) {
-        return rejectWithValue('Wrong email or password');
-      }
-      return data[0];
-    } catch (err) {
-      return rejectWithValue(err.response?.data || 'Login failed');
+export const authAsyncAction = {
+  login: createAsyncThunk('auth/login', async ({ email, password }) => {
+    const data = await authService.login(email, password);
+    if (!data || !Array.isArray(data) || data.length === 0) {
+      throw new Error('Wrong email or password');
     }
-  }
-);
+    return data[0];
+  }),
+  signup: createAsyncThunk('auth/signup', async (userData, { rejectWithValue }) => {
+    try {
+      const data = await authService.signup(userData);
+      return data;
+    } catch (err) {
+      return rejectWithValue(err?.response?.data || 'Signup failed');
+    }
+  }),
+};

--- a/src/store/authSlice.js
+++ b/src/store/authSlice.js
@@ -42,22 +42,35 @@ const authSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder
-      .addCase(authAsyncAction.pending, (state) => {
+      .addCase(authAsyncAction.login.pending, (state) => {
         state.status.user.login = 'PENDING';
         state.error = null;
         state.isAuthenticated = false;
       })
-      .addCase(authAsyncAction.fulfilled, (state, action) => {
+      .addCase(authAsyncAction.login.fulfilled, (state, action) => {
         state.status.user.login = 'SUCCESS';
         state.user = action.payload;
         state.error = null;
         state.isAuthenticated = true;
       })
-      .addCase(authAsyncAction.rejected, (state, action) => {
+      .addCase(authAsyncAction.login.rejected, (state, action) => {
         state.status.user.login = 'REJECTED';
         state.user = null;
         state.error = action.payload || 'Login failed';
         state.isAuthenticated = false;
+      })
+      .addCase(authAsyncAction.signup.pending, (state) => {
+        state.status.user.signup = 'PENDING';
+        state.error = null;
+      })
+      .addCase(authAsyncAction.signup.fulfilled, (state) => {
+        state.status.user.signup = 'SUCCESS';
+        state.error = null;
+      })
+      .addCase(authAsyncAction.signup.rejected, (state, action) => {
+        state.status.user.signup = 'REJECTED';
+        state.user = null;
+        state.error = action.payload || 'Signup failed';
       });
   },
 });


### PR DESCRIPTION
Main highlights:

- Pages: Created Sign Up Page layouts & refactored Log In Page
- Docs: Updated README.md

How to Test:

- Run json-server on port 3000 with mock db.json for user auth. "user" database must include 'email' and 'password'
- Run the frontend (npm run dev).
- Navigate to the Landing Page → Log In → test form submission.

Next steps:

- Add sending & receiving message function & temporary Dashboard Page